### PR TITLE
Add Bootstrap, clean up nav bar, and stripe tables

### DIFF
--- a/aesops/templates/base.html
+++ b/aesops/templates/base.html
@@ -3,21 +3,44 @@
 <html>
 
 <head>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <title>Aesop's Tables</title>
 </head>
 
 <body>
-    <div>
-        Aesop's Tables:
-        <a href="{{ url_for('index') }}">Tournament Directory</a>
-        {% if current_user.is_anonymous %}
-        <a href="{{ url_for('login') }}">Login</a>
-        {% else %}
-        <a>{{ current_user.username }}</a>
-        <a href="{{ url_for('logout') }}">Logout</a>
-        {% endif %}
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark px-3">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="#">Aesop's Tables</a>
+        
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+              <li class="nav-item">
+                <a class="nav-link" aria-current="page" href="{{ url_for('index') }}">Tournament Directory</a>
+              </li>
+            </ul>
+            <ul class="navbar-nav mb-2 mb-lg-0">
+              {% if current_user.is_anonymous %}
+              <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}">Log In</a></li>
+              {% else %}
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    {{ current_user.username }}
+                </a>
+                <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+                  <li><a class="dropdown-item" href="{{ url_for('logout') }}">Log Out</a></li>
+                </ul>
+              </li>
+              {% endif %}
+            </ul>
+        </div>
     </div>
+    </nav>
+          
     <hr>
     {% with messages = get_flashed_messages() %}
     {% if messages %}
@@ -29,6 +52,7 @@
     {% endif %}
     {% endwith %}
     {% block content %}{% endblock %}
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 </body>
 
 </html>

--- a/aesops/templates/base.html
+++ b/aesops/templates/base.html
@@ -10,8 +10,8 @@
 
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark px-3">
-        <div class="container-fluid">
-            <a class="navbar-brand" href="#">Aesop's Tables</a>
+        <div class="container">
+        <a class="navbar-brand" href="#">Aesop's Tables</a>
         
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
@@ -40,18 +40,20 @@
         </div>
     </div>
     </nav>
-          
-    <hr>
-    {% with messages = get_flashed_messages() %}
-    {% if messages %}
-    <ul>
-        {% for message in messages %}
-        <li>{{ message }}</li>
-        {% endfor %}
-    </ul>
-    {% endif %}
-    {% endwith %}
-    {% block content %}{% endblock %}
+    <div class="container">
+        <hr>
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+        <ul>
+            {% for message in messages %}
+            <li>{{ message }}</li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+    </div>
+    
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
 </body>
 

--- a/aesops/templates/index.html
+++ b/aesops/templates/index.html
@@ -4,7 +4,7 @@
 {% if current_user.is_authenticated %}
 <a href="{{ url_for('create_tournament') }}">Create Tournament</a>
 {% endif %}
-<table>
+<table class="table table-striped">
     <thead>
         <tr>
             <th>Tournament Name</th>

--- a/aesops/templates/round.html
+++ b/aesops/templates/round.html
@@ -7,7 +7,7 @@
     <a href="{{ url_for('round', tid=tournament.id, rnd=round)}}">{{round}}</a>
     {% endfor %}
 </h3>
-<table>
+<table class="table table-striped">
     <thead>
         <tr>
             <th>Table Number</th>


### PR DESCRIPTION
The JS is necessary for the drop-down to log out, which is a design element I like, but it's easy enough to change the design a bit and remove that if a no-JS solution is preferred. Bootstrap should get a pretty solid base from which to style everything consistently. 

Here's what the nav bar looks like after this change:

<img width="1116" alt="Screenshot 2023-04-06 at 12 04 34 AM" src="https://user-images.githubusercontent.com/1562769/230269422-1665f132-e44c-4c72-9201-eb2430a2699f.png">
<img width="1116" alt="Screenshot 2023-04-06 at 12 04 22 AM" src="https://user-images.githubusercontent.com/1562769/230269429-3f421cd6-0232-45db-95ca-ff4cad0cfd53.png">
<img width="767" alt="Screenshot 2023-04-06 at 12 04 51 AM" src="https://user-images.githubusercontent.com/1562769/230269430-1af0b887-54a2-495e-baf1-f7629d99a95f.png">

