### PR TITLE
When editing pairings manually, Table Number wasn't being set

### DIFF
--- a/aesops/routes.py
+++ b/aesops/routes.py
@@ -315,6 +315,7 @@ def edit_pairings(tid, rnd):
                 corp_player=Player.query.get(form.corp_player.data),
                 runner_player=Player.query.get(form.runner_player.data),
                 is_bye=is_bye,
+                table_number=form.table_number.data,
             )
             print(tournament.active_matches)
 

--- a/pairing/matchmaking.py
+++ b/pairing/matchmaking.py
@@ -12,7 +12,7 @@ class PairingException(Exception):
 
 
 def create_match(
-    tournament: Tournament, corp_player: Player, runner_player: Player, is_bye=False
+    tournament: Tournament, corp_player: Player, runner_player: Player, is_bye=False, table_number=None
 ):
     if is_bye:
         m = Match(
@@ -30,6 +30,8 @@ def create_match(
             rnd=tournament.current_round,
             is_bye=is_bye,
         )
+    if table_number:
+        m.table_numbe = table_number
     db.session.add(m)
     db.session.commit()
 


### PR DESCRIPTION
I noticed this bug while I was reorganizing some code.

When manually editing pairings, you can enter the table number on the form, but it's never propagated to the database.

This PR fixes that.