### PR TITLE
Add intentional draw, Close #10

### DIFF
--- a/aesops/blueprints/tournament_blueprint.py
+++ b/aesops/blueprints/tournament_blueprint.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, render_template, redirect, url_for, flash
 from flask_login import current_user, login_required
+from data_models.match import MatchReport
 from data_models.players import Player
 from data_models.tournaments import Tournament
 from data_models.model_store import db
@@ -111,4 +112,5 @@ def round(tid, rnd):
         rank_tables=rank_tables,
         get_faction=get_faction,
         t_logic=t_logic,
+        match_report=MatchReport,
     )

--- a/aesops/business_logic/elim_match.py
+++ b/aesops/business_logic/elim_match.py
@@ -1,4 +1,5 @@
 from data_models.exceptions import ConclusionError
+from data_models.match import MatchResult
 from data_models.model_store import db
 from data_models.top_cut import CutPlayer, ElimMatch
 import aesops.business_logic.top_cut as tc_logic
@@ -7,10 +8,10 @@ from .cut_tables import get_bracket
 
 
 def conclude(elim_match :ElimMatch):
-    if elim_match.result not in [-1, 1]:
+    if elim_match.result not in [MatchResult.CORP_WIN.value, MatchResult.RUNNER_WIN.value]:
         raise ConclusionError("No result recorded")
     elim_match.concluded = True
-    if elim_match.result == 1:
+    if elim_match.result == MatchResult.CORP_WIN.value:
         elim_match.winner_id = elim_match.corp_player_id
         elim_match.loser_id = elim_match.runner_player_id
     else:
@@ -21,12 +22,12 @@ def conclude(elim_match :ElimMatch):
     db.session.commit()
 
 def corp_win(elim_match :ElimMatch):
-    elim_match.result = 1
+    elim_match.result = MatchResult.CORP_WIN.value
     db.session.add(elim_match)
     db.session.commit()
 
 def runner_win(elim_match :ElimMatch):
-    elim_match.result = -1
+    elim_match.result = MatchResult.RUNNER_WIN.value
     db.session.add(elim_match)
     db.session.commit()
 
@@ -85,18 +86,18 @@ def determine_sides(elim_match :ElimMatch, is_second_final=False):
 
 def get_winner(elim_match :ElimMatch):
     """_summary_: Returns the winner of the match."""
-    if elim_match.result == 1:
+    if elim_match.result == MatchResult.CORP_WIN.value:
         return elim_match.corp_player
-    elif elim_match.result == -1:
+    elif elim_match.result == MatchResult.RUNNER_WIN.value:
         return elim_match.runner_player
     else:
         raise ConclusionError("Match has not been concluded")
 
 def get_loser(elim_match :ElimMatch):
     """_summary_: Returns the loser of the match."""
-    if elim_match.result == 1:
+    if elim_match.result == MatchResult.CORP_WIN.value:
         return elim_match.runner_player
-    elif elim_match.result == -1:
+    elif elim_match.result == MatchResult.RUNNER_WIN.value:
         return elim_match.corp_player
     else:
         raise ConclusionError("Match has not been concluded")

--- a/aesops/business_logic/match.py
+++ b/aesops/business_logic/match.py
@@ -1,27 +1,32 @@
 from data_models.exceptions import ConclusionError
-from data_models.match import Match
+from data_models.match import Match, MatchResult
 from data_models.model_store import db
 from . import players as p_logic
 
 def conclude(match :Match):
-    if match.result not in [-1, 0, 1]:
+    if match.result not in [MatchResult.CORP_WIN.Value, MatchResult.RUNNER_WIN.Value, MatchResult.DRAW.Value, MatchResult.INTENTIONAL_DRAW.Value]:
         raise ConclusionError("No result recorded")
     match.concluded = True
     db.session.add(match)
     db.session.commit()
 
 def corp_win(match :Match):
-    match.result = 1
+    match.result = MatchResult.CORP_WIN.value
     db.session.add(match)
     db.session.commit()
 
 def runner_win(match :Match):
-    match.result = -1
+    match.result = MatchResult.RUNNER_WIN.value
     db.session.add(match)
     db.session.commit()
 
 def tie(match :Match):
-    match.result = 0
+    match.result = MatchResult.DRAW.value
+    db.session.add(match)
+    db.session.commit()
+
+def intentional_draw(match :Match):
+    match.result = MatchResult.INTENTIONAL_DRAW.value
     db.session.add(match)
     db.session.commit()
 

--- a/aesops/business_logic/matchmaking.py
+++ b/aesops/business_logic/matchmaking.py
@@ -94,12 +94,10 @@ def legal_options(p1: Player, p2: Player) -> list[bool]:
 
 
 def side_cost(corp_player: Player, runner_player: Player):
-    balance_post = abs(p_logic.get_side_balance(corp_player) + 1) + abs(
-        p_logic.get_side_balance(runner_player) - 1
-    )
-    balance_pre = abs(p_logic.get_side_balance(corp_player)) + abs(
-        p_logic.get_side_balance(runner_player)
-    )
+    corp_bal = p_logic.get_side_balance(corp_player)
+    runner_bal = p_logic.get_side_balance(runner_player)
+    balance_post = abs(corp_bal + 1) + abs(runner_bal - 1)
+    balance_pre = abs(corp_bal) + abs(runner_bal)
     if balance_post > balance_pre and balance_pre != 0:
         return 1000
     return 8 ** abs(balance_post)

--- a/aesops/business_logic/players.py
+++ b/aesops/business_logic/players.py
@@ -1,3 +1,4 @@
+from data_models.match import MatchResult
 from data_models.model_store import db
 from data_models.players import Player
 
@@ -7,17 +8,17 @@ def get_record(player :Player) -> dict[str, float]:
     for match in player.runner_matches:
         if not match.concluded:
             continue
-        if match.result == -1 and match.concluded:
+        if match.result == MatchResult.RUNNER_WIN.value and match.concluded:
             score += 3
-        if match.result == 0 and match.concluded:
+        if match.result in [MatchResult.DRAW.value, MatchResult.INTENTIONAL_DRAW.value] and match.concluded:
             score += 1
         games_played += 1
     for match in player.corp_matches:
         if not match.concluded:
             continue
-        if match.result == 1 and match.concluded:
+        if match.result == MatchResult.CORP_WIN.value and match.concluded:
             score += 3
-        if match.result == 0 and match.concluded:
+        if match.result in [MatchResult.DRAW.value, MatchResult.INTENTIONAL_DRAW.value] and match.concluded:
             score += 1
         games_played += 1
     return {"score": score, "games_played": games_played}
@@ -103,12 +104,12 @@ def side_record(player :Player, side):
         if match.is_bye:
             continue
         if match.concluded:
-            if match.result == -1:
+            if match.result == MatchResult.RUNNER_WIN.value:
                 if side == "runner":
                     results["W"] += 1
                 else:
                     results["L"] += 1
-            elif match.result == 1:
+            elif match.result == MatchResult.CORP_WIN.value:
                 if side == "corp":
                     results["W"] += 1
                 else:

--- a/aesops/routes.py
+++ b/aesops/routes.py
@@ -11,7 +11,7 @@ from aesops.forms import (
 from flask import render_template, flash, redirect, url_for, request, Response
 from flask_login import current_user, login_required
 from data_models.exceptions import ConclusionError, PairingException
-from data_models.match import Match
+from data_models.match import Match, MatchReport
 from data_models.players import Player
 from data_models.top_cut import Cut, ElimMatch
 from data_models.tournaments import Tournament
@@ -72,14 +72,17 @@ def redirect_for_round(tid, rnd):
 def report_match(tid, rnd, mid, result):
     tournament = Tournament.query.get(tid)
     match = Match.query.get(mid)
-    if result == 2:
+    if result == MatchReport.RUNNER_WIN.value:
         m_logic.runner_win(match)
         return redirect_for_round(tid=tid, rnd=rnd)
-    if result == 1:
+    elif result == MatchReport.CORP_WIN.value:
         m_logic.corp_win(match)
         return redirect_for_round(tid=tid, rnd=rnd)
-    if result == 0:
+    elif result == MatchReport.DRAW.value:
         m_logic.tie(match)
+        return redirect_for_round(tid=tid, rnd=rnd)
+    elif result == MatchReport.INTENTIONAL_DRAW.value:
+        m_logic.intentional_draw(match)
         return redirect_for_round(tid=tid, rnd=rnd)
     return redirect(url_for("tournaments.round", tournament=tournament, rnd=rnd))
 
@@ -219,6 +222,7 @@ def edit_pairings(tid, rnd):
                 rank_tables=rank_tables,
                 get_faction=get_faction,
                 t_logic=t_logic,
+                match_report=MatchReport,
             )
     return render_template(
         "edit_pairings.html",
@@ -230,6 +234,7 @@ def edit_pairings(tid, rnd):
         rank_tables=rank_tables,
         get_faction=get_faction,
         t_logic=t_logic,
+        match_report=MatchReport,
     )
 
 

--- a/aesops/templates/_pairings.html
+++ b/aesops/templates/_pairings.html
@@ -31,12 +31,14 @@
         {% if (match.result is none and tournament.allow_self_results_report) or admin %}
         <th>
             {% if not match.is_bye %}
-            <a href="{{ url_for('report_match',tid=tournament.id, rnd=rnd, mid=match.id, result=1)}}"
+            <a href="{{ url_for('report_match',tid=tournament.id, rnd=rnd, mid=match.id, result=match_report.CORP_WIN.value)}}"
                 class="btn btn-primary">Corp Win</a>
-            <a href="{{ url_for('report_match',tid=tournament.id, rnd=rnd, mid=match.id, result=0)}}"
+            <a href="{{ url_for('report_match',tid=tournament.id, rnd=rnd, mid=match.id, result=match_report.DRAW.value)}}"
                 class="btn btn-primary">Tie</a>
-            <a href="{{ url_for('report_match',tid=tournament.id, rnd=rnd, mid=match.id, result=2)}}"
+            <a href="{{ url_for('report_match',tid=tournament.id, rnd=rnd, mid=match.id, result=match_report.RUNNER_WIN.value)}}"
                 class="btn btn-primary">Runner Win</a>
+            <a href="{{ url_for('report_match',tid=tournament.id, rnd=rnd, mid=match.id, result=match_report.INTENTIONAL_DRAW.value)}}"
+                class="btn btn-primary">Intentional Draw</a>
             {% endif %}
             {% if admin and tournament.current_round == rnd%}
             <a href="{{ url_for('delete_match', mid=match.id)}}" class="btn btn-danger">Delete Match</a>

--- a/aesops/utility.py
+++ b/aesops/utility.py
@@ -2,7 +2,7 @@ import requests
 import os
 import datetime
 from json import dump, load
-from data_models.match import Match
+from data_models.match import Match, MatchResult
 from data_models.players import Player
 from data_models.tournaments import Tournament
 import aesops.business_logic.players as p_logic
@@ -58,10 +58,11 @@ def get_runner_ids():
 
 
 def display_side_bias(player: Player):
-    if p_logic.get_side_balance(player) > 0:
-        return f"Corp +{p_logic.get_side_balance(player)}"
-    if p_logic.get_side_balance(player) < 0:
-        return f"Runner +{p_logic.get_side_balance(player)*-1}"
+    side_bal = p_logic.get_side_balance(player)
+    if side_bal > 0:
+        return f"Corp +{side_bal}"
+    elif side_bal < 0:
+        return f"Runner +{side_bal * -1}"
     return "Balanced"
 
 
@@ -81,11 +82,11 @@ def get_faction(corp_name: str):
 def format_results(match: Match):
     if match.result is None:
         return ""
-    if match.result == 1:
+    if match.result == MatchResult.CORP_WIN.value:
         return "3 - 0"
-    if match.result == -1:
+    if match.result == MatchResult.RUNNER_WIN.value:
         return "0 - 3"
-    if match.result == 0:
+    if match.result in [MatchResult.DRAW.value, MatchResult.INTENTIONAL_DRAW.value]:
         return "1 - 1"
 
 
@@ -162,8 +163,8 @@ def get_json(tid):
                         "tableNumber": match.table_number,
                         "corpPlayer": corp_id,
                         "runnerPlayer": runner_id,
-                        "winner_id": corp_id if match.result == 1 else runner_id,
-                        "loser_id": runner_id if match.result == 1 else corp_id,
+                        "winner_id": corp_id if match.result == MatchResult.CORP_WIN.value else runner_id,
+                        "loser_id": runner_id if match.result == MatchResult.CORP_WIN.value else corp_id,
                     }
                 )
             t_json["rounds"].append(match_list)

--- a/data_models/match.py
+++ b/data_models/match.py
@@ -1,5 +1,19 @@
 from data_models.model_store import db
+from sqlalchemy import Enum
 
+import enum
+
+class MatchResult(enum.Enum):
+    CORP_WIN = 1
+    RUNNER_WIN = -1
+    DRAW = 0
+    INTENTIONAL_DRAW = 9
+
+class MatchReport(enum.Enum):
+    CORP_WIN = 1
+    RUNNER_WIN = 2
+    DRAW = 0
+    INTENTIONAL_DRAW = 9
 
 class Match(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -2,7 +2,7 @@
 
 [alembic]
 # template used to generate migration files
-# file_template = %%(rev)s_%%(slug)s
+file_template = %%(year)d-%%(month).2d-%%(day).2d_%%(rev)s_%%(slug)s
 
 # set to 'true' to run the environment during
 # the 'revision' command, regardless of autogenerate


### PR DESCRIPTION
This will add an Intentional Draw button for match reporting purposes, to close #10 

This counts just like a regular draw for all match reporting purposes, and side balance reasons.

Internally, I've removed reliance on the "Magic Numbers" for the stages of reporting results, and the database entries for the result. I've added some Enumerations to refer to instead of attempting to remember what each result means.