### PR TITLE
Two small errors? (typo, require_login preselection)

### DIFF
--- a/aesops/routes.py
+++ b/aesops/routes.py
@@ -379,6 +379,7 @@ def edit_tournament(tid):
         tournament.description = form.description.data
         tournament.allow_self_registration = form.allow_self_registration.data
         tournament.allow_self_results_report = form.allow_self_results_report.data
+        tournament.require_login = form.require_login.data
         tournament.visible = form.visible.data
         tournament.require_decklist = form.require_decklist.data
         db.session.commit()

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Program trying to run single sided swiss Netrunner events.
 
 For now to get it started:
 
-install requirements using `pip install -r requirements.text`
+install requirements using `pip install -r requirements.txt`
 
 then run:
 `flask db init`


### PR DESCRIPTION
When editing a tournament, the new `require login` feature was unselected regardless if it was selected before. I think there was just a missing line in routes.py, but I haven't been able to get it to run locally so this is untested. While trying to get it to run on my machine, I discovered that the instruction to install the requirements used the file `requirements.text` which wasn't existing, so I changed this to `requirements.txt`.

This is my first pull request ever, so I hope I did everything right