### PR TITLE
major overhaul to fix score/sos calculation runtimes

### DIFF
--- a/aesops/business_logic/match.py
+++ b/aesops/business_logic/match.py
@@ -51,9 +51,9 @@ def reset(match: Match):
 def delete(match: Match):
     if match.is_bye:
         match.corp_player.recieved_bye = False
-        p_logic.reset(match.corp_player)
-    else:
-        p_logic.reset(match.corp_player)
-        p_logic.reset(match.runner_player)
+        # p_logic.reset(match.corp_player)
+    # else:
+    #     p_logic.reset(match.corp_player)
+    #     p_logic.reset(match.runner_player)
     db.session.delete(match)
     db.session.commit()

--- a/aesops/business_logic/players.py
+++ b/aesops/business_logic/players.py
@@ -2,6 +2,10 @@ from data_models.match import MatchResult
 from data_models.model_store import db
 from data_models.players import Player
 
+# Depreciating all of these because hitting the database for every player is not efficient
+# Caching the results is a better solution for readability than my mess in the tournament logic
+# But I'm not sure how to implement that yet
+
 
 def get_record(player: Player, count_byes=True) -> dict[str, float]:
     score = 0
@@ -41,63 +45,56 @@ def get_side_balance(player: Player):
     )
 
 
-def get_average_score(player: Player) -> float:
-    return get_record(player)["score"] / max(get_record(player)["games_played"], 1)
+# def get_average_score(player: Player) -> float:
+#     return get_record(player)["score"] / max(get_record(player)["games_played"], 1)
 
 
-def get_sos(player: Player) -> float:
-    opp_average_score = sum(
-        [get_average_score(m.corp_player) for m in player.runner_matches]
-    )
-    opp_average_score += sum(
-        [
-            get_average_score(m.runner_player)
-            for m in player.corp_matches
-            if m.is_bye == False
-        ]
-    )
-    return round(
-        opp_average_score
-        / max(get_record(player, count_byes=False)["games_played"], 1),
-        3,
-    )
+# def get_sos(player: Player) -> float:
+#     opp_average_score = sum(
+#         [get_average_score(m.corp_player) for m in player.runner_matches]
+#     )
+#     opp_average_score += sum(
+#         [
+#             get_average_score(m.runner_player)
+#             for m in player.corp_matches
+#             if m.is_bye == False
+#         ]
+#     )
+#     return round(
+#         opp_average_score
+#         / max(get_record(player, count_byes=False)["games_played"], 1),
+#         3,
+#     )
 
 
-def get_esos(player: Player) -> float:
-    opp_total_sos = sum([get_sos(m.corp_player) for m in player.runner_matches])
-    opp_total_sos += sum(
-        [get_sos(m.runner_player) for m in player.corp_matches if m.is_bye == False]
-    )
-    return round(
-        opp_total_sos / max(get_record(player, count_byes=False)["games_played"], 1), 3
-    )
+# def get_esos(player: Player) -> float:
+#     opp_total_sos = sum([get_sos(m.corp_player) for m in player.runner_matches])
+#     opp_total_sos += sum(
+#         [get_sos(m.runner_player) for m in player.corp_matches if m.is_bye == False]
+#     )
+#     return round(
+#         opp_total_sos / max(get_record(player, count_byes=False)["games_played"], 1), 3
+#     )
 
 
-def update_score(player: Player):
-    old_score = player.score
-    old_sos = player.sos
-    old_esos = player.esos
-    player.score = get_record(player)["score"]
-    player.sos = get_sos(player)
-    player.esos = get_esos(player)
-    # if old_score != player.score:
-    #     print(f"Updated {player.name}'s score from {old_score} to {player.score}")
-    # if old_sos != player.sos:
-    #     print(f"Updated {player.name}'s sos from {old_sos} to {player.sos}")
-    db.session.add(player)
-    db.session.commit()
+# def update_score(player: Player):
+#     player.score = get_record(player)["score"]
+#     player.sos = get_sos(player)
+#     player.esos = get_esos(player)
+#     db.session.add(player)
+#     db.session.commit()
 
 
-def update_sos_esos(player: Player):
-    player.sos = get_sos(player)
-    player.esos = get_esos(player)
-    db.session.add(player)
-    db.session.commit()
+# def update_sos_esos(player: Player):
+#     player.sos = get_sos(player)
+#     player.esos = get_esos(player)
+#     db.session.add(player)
+#     db.session.commit()
 
 
-def reset(player: Player):
-    update_score(player)
-    update_sos_esos(player)
+# def reset(player: Player):
+#     update_score(player)
+#     update_sos_esos(player)
 
 
 def drop(player: Player):
@@ -147,7 +144,6 @@ def side_record(player: Player, side):
 def reveal_decklists(player, tournament):
     if tournament.reveal_decklists:
         return True
-    if not tournament.reveal_cut_decklists:
-        return False
-    if player.cut_player:
+    if tournament.reveal_cut_decklists and player.cut_player:
         return True
+    return False

--- a/tests/simulation_utils.py
+++ b/tests/simulation_utils.py
@@ -24,7 +24,8 @@ def sim_round(t: Tournament):
             m_logic.tie(m)
         else:
             m_logic.runner_win(m)
-
+    db.session.commit()
+    t = Tournament.query.get(t.id)
     t_logic.conclude_round(t)
 
 


### PR DESCRIPTION
Moved all the logic for calculating Score, Strength of Schedule, and ESoS into the tournament business logic.

This was done so that I could manually implement a cache (because I didn't want to spend the time to figure that out). When calculating the standings at the end of a round (or rather whenever aesops.business_logic.conclude_round is called) the matches and players get loaded into memory and updates happen there.

Prior to this change the call time doubled for each successive round, causing it to sometimes exceed the 30 second timeout request. This change in local testing makes it take a flat 5 seconds to pair 300 players.