### PR TITLE
Briefly document decklist parser

### DIFF
--- a/aesops/business_logic/decklist.py
+++ b/aesops/business_logic/decklist.py
@@ -4,7 +4,28 @@ from aesops import app
 from aesops.utility import get_cards, convert_stipped_to_card
 from data_models.users import User
 
-
+"""
+decklist_parser parses a decklist in one of two formats:
+* The Jinteki.net format produced by NetrunnerDB, which is a list of cards like
+```
+1 Burner
+3 Creative Commission
+2 "Pretty" Mary Da Silva
+...
+```
+* The output of copy/pasting a list from Jinteki.net, which is like the above but
+also includes headings:
+```
+Event (14)
+1  Burner 
+3  Creative Commission
+Resource (12)
+2  "Pretty" Mary da Silva
+...
+```
+This verifies that the list only contains valid Netrunner cards before saving.
+It does _not_ verify deck legality.
+"""
 def decklist_parser(decklist: str):
     cardtypes = [
         "Event",
@@ -22,6 +43,11 @@ def decklist_parser(decklist: str):
     decklist = decklist.replace("•", "")
     decklist_cards = decklist.split("\n")
     print(decklist_cards)
+    # Create a dictionary mapping card name to its quantity.
+    # Note that if a user provides a copy/paste deck from Jinteki.net, there
+    # will be entries like "Agenda (5)" in their decklist which are converted
+    # to "(5)": "Agenda" in this decklist_dict.
+    # (Documenting this because it is very easy to miss.)
     decklist_dict = {
         decklist_cards.split(" ", 1)[1].strip(): decklist_cards.split(" ", 1)[0]
         for decklist_cards in decklist_cards
@@ -33,6 +59,8 @@ def decklist_parser(decklist: str):
         # formatted version (convert_stipped_to_card). Thus, we keep track of
         # the qty for later.
         qty = decklist_dict[card_name]
+        # Note that entries like "Agenda (5)" will be "(5)": "Agenda", so have
+        # qty = "Agenda". This check ignores lines like those.
         if qty in cardtypes:
             continue
         card_name = card_name.strip()


### PR DESCRIPTION
To avoid other programmers falling into some of the pitfalls I did when editing the decklist parser, there are now some brief comments which confirm exactly which formats of decklist are expected!

This is not urgent at all, but given that it's just a documentation change it should be easy to check and merge.