### PR TITLE
UI improvements for round pairing list

### DIFF
--- a/aesops/blueprints/tournament_blueprint.py
+++ b/aesops/blueprints/tournament_blueprint.py
@@ -113,21 +113,31 @@ def add_player(tid: int):
     )
 
 
-@tournament_blueprint.route("/<int:tid>/<int:rnd>", methods=["GET", "POST"])
-def round(tid, rnd):
-    tournament = Tournament.query.get(tid)
+def _render_round(tournament_: Tournament, rnd: int):
     return render_template(
         "round.html",
-        tournament=tournament,
+        tournament=tournament_,
         rnd=rnd,
         format_results=format_results,
-        admin=u_logic.has_admin_rights(current_user, tid),
+        admin=u_logic.has_admin_rights(current_user, tournament_.id),
         rank_tables=rank_tables,
         get_faction=get_faction,
         t_logic=t_logic,
         match_report=MatchReport,
         has_reporting_rights=u_logic.has_reporting_rights,
     )
+
+
+@tournament_blueprint.route("/<int:tid>/<int:rnd>", methods=["GET", "POST"])
+def round(tid: int, rnd: int):
+    tournament_ = Tournament.query.get(tid)
+    return _render_round(tournament_, rnd)
+
+
+@tournament_blueprint.route("/<int:tid>/current", methods=["GET", "POST"])
+def round_current(tid: int):
+    tournament_ = Tournament.query.get(tid)
+    return _render_round(tournament_, tournament_.current_round)
 
 
 @login_required

--- a/aesops/templates/_pairings.html
+++ b/aesops/templates/_pairings.html
@@ -10,7 +10,7 @@
             {% endif %}
         </tr>
     </thead>
-    {% for match in rank_tables(t_logic.get_round(tournament, round=rnd)) %}
+    {% for match in rank_tables(t_logic.get_round(tournament, round=rnd), current_user) %}
     <tr>
         <th>{{ match.table_number }}</th>
         <th>{{ match.corp_player.name }} {% if match.corp_player.pronouns %} ({{match.corp_player.pronouns}}) {% endif

--- a/aesops/templates/_tournament_header.html
+++ b/aesops/templates/_tournament_header.html
@@ -19,6 +19,9 @@
             class="text-primary fs-4 d-inline-block me-3">{{round}}
         </a>
         {% endfor %}
+        <a href="{{ url_for('tournaments.round_current', tid=tournament.id)}}"
+           class="text-primary fs-4 d-inline-block me-3">Current
+        </a>
         {% endif %}
     </div>
     <div class="col-md-3">

--- a/aesops/templates/cut_round.html
+++ b/aesops/templates/cut_round.html
@@ -15,7 +15,7 @@
             {% endif %}
         </tr>
     </thead>
-    {% for match in rank_tables(tc_logic.get_round(tournament.cut, rnd=rnd)) %}
+    {% for match in rank_tables(tc_logic.get_round(tournament.cut, rnd=rnd), current_user) %}
     <tr>
         <th>{{ match.table_number }}</th>
         <th>{{ match.corp_player.player.name }}<br>

--- a/aesops/utility.py
+++ b/aesops/utility.py
@@ -5,6 +5,7 @@ from json import dump, load
 from data_models.match import Match, MatchResult
 from data_models.players import Player
 from data_models.tournaments import Tournament
+from data_models.users import User
 import aesops.business_logic.players as p_logic
 import aesops.business_logic.top_cut as tc_logic
 import aesops.business_logic.tournament as t_logic
@@ -71,8 +72,16 @@ def display_side_bias(player: Player):
     return "Balanced"
 
 
-def rank_tables(match_list: list[Match]):
-    match_list.sort(key=lambda x: x.table_number or 1000)
+def rank_tables(match_list: list[Match], current_user: User):
+    current_user_id = current_user.id if not current_user.is_anonymous else None
+    # List table for the current user's player first.
+    match_list.sort(
+        key=lambda x: (
+            not ((x.corp_player and
+                  x.corp_player.user.id == current_user_id) or
+                 (x.runner_player and
+                  x.runner_player.user.id == current_user_id)),
+            x.table_number or 1000))
     return match_list
 
 


### PR DESCRIPTION
Please feel free to ignore this PR or let me know if you want any of the things below excluded / to work differently.

1. Added view for "current round", so users don't need to switch pages to see the current pairing.
2. Listing current user's player table first.

![Screenshot from 2024-07-31 12-31-30](https://github.com/user-attachments/assets/9043ad8b-d6ba-4b83-8444-abd8776b7160)