### PR TITLE
Improve performance of the tournament page

### DIFF
--- a/aesops/blueprints/tournament_blueprint.py
+++ b/aesops/blueprints/tournament_blueprint.py
@@ -15,7 +15,7 @@ from aesops.forms import (
 from data_models.users import User
 import aesops.business_logic.users as u_logic
 from aesops.utility import (
-    display_side_bias,
+    render_side_bias,
     format_results,
     get_faction,
     rank_tables,
@@ -33,14 +33,25 @@ def redirect_for_tournament(tid):
 @tournament_blueprint.route("/<int:tid>/standings", methods=["GET", "POST"])
 def tournament(tid):
     tournament = Tournament.query.get(tid)
+
+    # Rank the players in the tournament and calculate their info required
+    # to be rendered on the page
+    result = t_logic.calculate_player_ranks(tournament)
+
+    # Generate the cut standings
+    cut_standings = None
+    if tournament.cut is not None:
+        cut_standings = tc_logic.get_standings(tournament.cut)
+
     return render_template(
         "tournament.html",
         tournament=tournament,
         admin=u_logic.has_admin_rights(current_user, tid),
-        display_side_bias=display_side_bias,
+        render_side_bias=render_side_bias,
         get_faction=get_faction,
         t_logic=t_logic,
-        tc_logic=tc_logic,
+        cut_standings=cut_standings,
+        result=result,
         p_logic=p_logic,
         last_concluded_round=(
             tournament.current_round

--- a/aesops/templates/tournament.html
+++ b/aesops/templates/tournament.html
@@ -4,7 +4,7 @@
 
 {% include '_tournament_header.html' %}
 <br>
-{% if tournament.cut is not none %}
+{% if cut_standings is not none %}
 
 <div class="row">
     <div class="col-md-4"></div>
@@ -18,16 +18,16 @@
                 </tr>
             </thead>
             <tbody>
-                {% for _ in range(tc_logic.get_standings(tournament.cut)['unranked_players']) %}
+                {% for _ in range(cut_standings['unranked_players']) %}
                 <tr>
                     <td> - </td>
                     <td> - </td>
                 </tr>
                 {% endfor %}
-                {% for player in tc_logic.get_standings(tournament.cut)['ranked_players'] %}
+                {% for player in cut_standings['ranked_players'] %}
                 <tr>
                     <td>{{ player.player.name }}</td>
-                    <td>{{ loop.index0 + 1 + tc_logic.get_standings(tournament.cut)['unranked_players']}}</td>
+                    <td>{{ loop.index0 + 1 + cut_standings['unranked_players']}}</td>
                 </tr>
                 {% endfor %}
         </table>
@@ -53,45 +53,43 @@
             <th>Side Bias</th>
         </tr>
     </thead>
-    {% for player in t_logic.rank_players(tournament) %}
+    {% for player in result %}
     <tr>
         <td>{{ loop.index0 + 1 }}</td>
-        <td>{{ player.name }} {% if player.first_round_bye %} {{"*"}} {%
-            endif %}<br>{% if player.pronouns %} {{player.pronouns}} {% endif %}</td>
+        <td>{{ player['player'].name }} {% if player['player'].first_round_bye %} {{"*"}} {%
+            endif %}<br>{% if player['player'].pronouns %} {{player['player'].pronouns}} {% endif %}</td>
 
         <td>
             {% if tournament.current_round != 0 or admin %}
-            <span class="{{ get_faction(player.corp)}}">{{ player.corp }}</span><br>{{
-            p_logic.side_record(player, "corp")['W']}}-{{
-            p_logic.side_record(player, "corp")['L']}}-{{ p_logic.side_record(player, "corp")['T']}}
+            <span class="{{ get_faction(player['player'].corp)}}">{{ player['player'].corp }}</span><br>
+            {{ player['corp_record']['W'] }}-{{ player['corp_record']['L'] }}-{{ player['corp_record']['T'] }}
             {% endif %}
         </td>
         <td>
             {% if tournament.current_round != 0 or admin%}
-            <span class="{{ get_faction(player.runner)}}">{{ player.runner }}</span><br> {{
-            p_logic.side_record(player, "runner")['W']}}-{{
-            p_logic.side_record(player, "runner")['L']}}-{{ p_logic.side_record(player, "runner")['T']}}
+            <span class="{{ get_faction(player['player'].runner)}}">{{ player['player'].runner }}</span><br>
+            {{ player['runner_record']['W'] }}-{{ player['runner_record']['L'] }}-{{ player['runner_record']['T'] }}
             {% endif %}
         </td>
-        <td>{{ p_logic.get_record(player)['score'] }}</td>
-        <td>{{ "%0.3f"|format(player.sos) }}</td>
-        <td>{{ "%0.3f"|format(player.esos) }}</td>
-        <td>{{ display_side_bias(player) }}</td>
+        <td>{{ player['score'] }}</td>
+        <td>{{ "%0.3f"|format(player['player'].sos) }}</td>
+        <td>{{ "%0.3f"|format(player['player'].esos) }}</td>
+        <td>{{ render_side_bias(player['side_bias']) }}</td>
 
         <td>
             {% if admin %}
-            <a href="{{ url_for('edit_player', pid=player.id) }}" class="btn btn-success">Edit</a>
+            <a href="{{ url_for('edit_player', pid=player['player'].id) }}" class="btn btn-success">Edit</a>
             {% if tournament.current_round == 0 %}
-            <a href="{{ url_for('delete_player', pid=player.id) }}" class="btn btn-danger">Delete</a>
+            <a href="{{ url_for('delete_player', pid=player['player'].id) }}" class="btn btn-danger">Delete</a>
             {% endif %}
             {% if player.active %}
-            <a href="{{ url_for('drop_player', pid=player.id) }}" class="btn btn-warning">Drop</a>
+            <a href="{{ url_for('drop_player', pid=player['player'].id) }}" class="btn btn-warning">Drop</a>
             {% else %}
-            <a href="{{ url_for('undrop_player', pid=player.id) }}" class="btn btn-primary">Undrop</a>
+            <a href="{{ url_for('undrop_player', pid=player['player'].id) }}" class="btn btn-primary">Undrop</a>
             {% endif %}
             {% endif %}
-            {% if admin or p_logic.reveal_decklists(player, tournament) %}
-            <a href="{{ url_for('tournaments.display_decklist', tid=tournament.id, pid=player.id) }}"
+            {% if admin or p_logic.reveal_decklists(player['player'], tournament) %}
+            <a href="{{ url_for('tournaments.display_decklist', tid=tournament.id, pid=player['player'].id) }}"
                 class="btn btn-primary">View
                 Decklist</a>
             {% endif %}

--- a/aesops/utility.py
+++ b/aesops/utility.py
@@ -20,14 +20,12 @@ def get_corp_ids():
 def get_runner_ids():
     return cards.data.runner_ids()
 
-def display_side_bias(player: Player):
-    side_bal = p_logic.get_side_balance(player)
+def render_side_bias(side_bal):
     if side_bal > 0:
         return f"Corp +{side_bal}"
     elif side_bal < 0:
         return f"Runner +{side_bal * -1}"
     return "Balanced"
-
 
 def rank_tables(match_list: list[Match]):
     match_list.sort(key=lambda x: x.table_number or 1000)


### PR DESCRIPTION
This change includes additional performance improvements for the tournament page, mostly related to efficient access to the database.

In the previous version, the players were initially ranked by 3 factors: esos, sos, and score. The esos and sos scores are calculated as results are recorded and fairly efficient. However one main driver of latency here is including the score in the calculation by calling the player business logic's 'get_record' function. This function iterates all of the players results, both corp and runner, meaning that every time one player was compared to another in the sorting algorithm, each player's matches were iterated and evaluated again.

In addition to this, 'get_record' is also called again when rendering the results page, 6 times each per player, which is another 6 iterations of each players matches.

This change improves this by ensuring we only look at each match once, and incrementally update the record for each player involved in the match accordingly, before sorting them once at the end, using their score value that we calculated during the single iteration of matches.

In addition to this, the calculation of the top cut rankings was called 3 times when rendering the page, so we make the optimization of only calling it once, and reusing the results multiple times when rendering.

On the machine used to develop these changes, the 99%ile latency has improved quite a bit on a tournament with 250 participants.

```
| Concurrent Reads | Prior Latency | New Latency |
| 1                | 158ms         | 39ms        |
| 2                | 343ms         | 56ms        |
| 5                | 1111ms        | 207ms       |
| 10               | 2175ms        | 479ms       |
```