### PR TITLE
Change in side bias to reduce bye overmatching

### DIFF
--- a/aesops/business_logic/matchmaking.py
+++ b/aesops/business_logic/matchmaking.py
@@ -125,7 +125,7 @@ def legal_options(p1: Player, p2: Player) -> list[bool]:
 def side_cost(corp_player: Player, runner_player: Player):
     corp_bal = p_logic.get_side_balance(corp_player)
     runner_bal = p_logic.get_side_balance(runner_player)
-    balance_post = max(abs(corp_bal + 1), abs(runner_bal - 1))
+    balance_post = max(abs(max(corp_bal, 0)), abs(min(runner_bal, 0)))
     return 8 ** abs(balance_post)
 
 
@@ -140,9 +140,9 @@ def calc_cost(corp_player: Player, runner_player: Player):
         side_cost(corp_player, runner_player)
         + score_cost(corp_player, runner_player)
         + (has_played(corp_player, runner_player) * 5)
-        + bye_vs_bye_penalty(
-            corp_player, runner_player, corp_player.tournament.current_round
-        )
+        # + bye_vs_bye_penalty(
+        #     corp_player, runner_player, corp_player.tournament.current_round
+        # )
     )
 
 
@@ -153,7 +153,7 @@ def find_min_edge(p1: Player, p2: Player):
         min_cost = min(calc_cost(p1, p2), min_cost)
     if options[1]:
         min_cost = min(calc_cost(p2, p1), min_cost)
-    print(f"Min cost between {p1.name} and {p2.name}: {min_cost}")
+    # print(f"Min cost between {p1.name} and {p2.name}: {min_cost}")
     return min_cost
 
 

--- a/aesops/business_logic/matchmaking.py
+++ b/aesops/business_logic/matchmaking.py
@@ -126,13 +126,13 @@ def side_cost(corp_player: Player, runner_player: Player):
     corp_bal = p_logic.get_side_balance(corp_player)
     runner_bal = p_logic.get_side_balance(runner_player)
     balance_post = max(abs(max(corp_bal, 0)), abs(min(runner_bal, 0)))
-    return 8 ** abs(balance_post)
+    return 50 ** abs(balance_post)
 
 
 def score_cost(corp_player: Player, runner_player: Player):
     c_score = p_logic.get_record(corp_player)["score"]
     r_score = p_logic.get_record(runner_player)["score"]
-    return abs((c_score - r_score + 1) * (c_score - r_score)) / 6
+    return (c_score - r_score) ** 2
 
 
 def calc_cost(corp_player: Player, runner_player: Player):

--- a/aesops/business_logic/tournament.py
+++ b/aesops/business_logic/tournament.py
@@ -233,9 +233,9 @@ def calculate_player_ranks(tournament: Tournament):
     if tournament.current_round == 0:
         result.sort(key=lambda p: p["player"].name.lower())
     else:
-        result.sort(key=lambda p: p["player"].esos, reverse=True)
-        result.sort(key=lambda p: p["player"].sos, reverse=True)
-        result.sort(key=lambda p: p["score"], reverse=True)
+        result.sort(
+            key=lambda p: (p["score"], p["player"].sos, p["player"].esos), reverse=True
+        )
 
     return result
 

--- a/aesops/business_logic/tournament.py
+++ b/aesops/business_logic/tournament.py
@@ -16,6 +16,7 @@ def add_player(
     corp_deck=None,
     runner_deck=None,
     user_id=None,
+    first_round_bye=False,
 ) -> Player:
     p = Player(
         name=name,
@@ -25,6 +26,7 @@ def add_player(
         runner_deck=runner_deck,
         tid=tournament.id,
         uid=None if user_id is None else user_id,
+        first_round_bye=first_round_bye,
     )
     db.session.add(p)
     db.session.commit()
@@ -62,7 +64,7 @@ def get_record_from_memory(player: Player, matches: dict, count_byes=True):
 
 
 def update_score_from_memory(player: Player, matches=dict):
-    return get_record_from_memory(player, matches)["score"]
+    return get_record_from_memory(player, matches, count_byes=True)["score"]
 
 
 def get_average_score_from_memory(player: Player, matches: dict):
@@ -276,7 +278,7 @@ def bye_setup(tournament: Tournament) -> tuple[list[Player], Player]:
             if not p.received_bye
             and p.active
             and (
-                len(p.runner_matches) + len(p.corp_matches) > 0
+                p_logic.get_record(p, count_byes=False)["games_played"] > 0
             )  # This is to prevent late joiners from getting a bye their first round
         ]
     else:

--- a/aesops/templates/index.html
+++ b/aesops/templates/index.html
@@ -1,9 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<li class="alert alert-primary" role="alert">25/5/11 Enabled First Round Byes - will see * next to players who are
-    registred with First Round Byes.</li>
-<li class="alert alert-primary" role="alert">25/5/17 Fixed/Improved ID Registration & ABR Export</li>
+<li class="alert alert-primary" role="alert">25-07-08 Modified pairing algorithm to reduce bye vs bye likelihood</li>
 {% if current_user.is_authenticated %}
 <a href="{{ url_for('tournaments.create_tournament') }}" class="btn btn-primary">Create Tournament</a>
 {% endif %}

--- a/config.py
+++ b/config.py
@@ -10,4 +10,4 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SECRET_KEY = os.environ.get("SECRET_KEY") or "a-secret-key"
     LOG_TO_STDOUT = os.environ.get("LOG_TO_STDOUT")
-    TOURNAMENTS_PER_PAGE = 10
+    TOURNAMENTS_PER_PAGE = 20

--- a/tests/simulation_utils.py
+++ b/tests/simulation_utils.py
@@ -1,32 +1,60 @@
-from random import choices, random
+from random import choices, random, randint
 from string import ascii_uppercase
+from aesops import app
+from data_models.model_store import db
 from data_models.tournaments import Tournament
+from data_models.players import Player
+from data_models.match import Match
 import aesops.business_logic.match as m_logic
 import aesops.business_logic.tournament as t_logic
+import aesops.business_logic.players as p_logic
 from aesops.business_logic.matchmaking import pair_round
-from data_models.model_store import db
 import tqdm
+from timeit import default_timer as timer
 
 
-def create_players(t: Tournament, count: int):
-    for _ in range(count):
+def create_players(t: Tournament, count: int, num_byes: int = 0):
+    for i in range(num_byes):
+        t_logic.add_player(t, ascii_uppercase[i], first_round_bye=True)
+    for _ in range(count - num_byes):
         t_logic.add_player(t, "".join(choices(ascii_uppercase, k=5)))
 
 
+def create_results(m: Match):
+    if m.is_bye:
+        return
+    if m.concluded:
+        return
+    r = random()
+    if r < 0.49:
+        m_logic.corp_win(m)
+    elif r < 0.51:
+        m_logic.tie(m)
+    else:
+        m_logic.runner_win(m)
+    return
+
+
 def sim_round(t: Tournament):
+    # start_time = timer()
     for m in t.active_matches:
-        if m.concluded:
-            continue
-        r = random()
-        if r < 0.49:
-            m_logic.corp_win(m)
-        elif r < 0.51:
-            m_logic.tie(m)
-        else:
-            m_logic.runner_win(m)
+        create_results(m)
     db.session.commit()
-    t = Tournament.query.get(t.id)
+    t = db.session.get(Tournament, t.id)
     t_logic.conclude_round(t)
+    # print(
+    #     f"Round {t.current_round} took {timer() - start_time:.2f} seconds to conclude"
+    # )
+
+
+def time_pair_round(t: Tournament):
+    # start_time = timer()
+    pair_round(t)
+    db.session.commit()
+    # print(
+    #     f"Pairing round {t.current_round} took {timer() - start_time:.2f} seconds to complete"
+    # )
+    return t
 
 
 def display_players(t: Tournament):
@@ -34,54 +62,188 @@ def display_players(t: Tournament):
         print(f"{p.name} {p.score} {p.sos} {p.esos}")
 
 
-def sim_tournament(n_players: int, n_rounds: int, name: str = None):
+def drop_players(t: Tournament, drops_per_round: int, drop_rate: float = 0.9):
+    if drops_per_round <= 0:
+        return
+    for i in range(drops_per_round):
+        ranked_players = t_logic.rank_players(t)
+        active_ranked_players = [p for p in ranked_players if p.active]
+        if random() < drop_rate:
+            active_ranked_players[-i - 1].active = False
+            db.session.add(active_ranked_players[-i - 1])
+        db.session.commit()
+
+
+def sim_tournament(
+    n_players: int,
+    n_rounds: int,
+    name: str = None,
+    num_byes: int = 0,
+    drops_per_round: int = 0,
+    drop_rate: float = 0.9,
+):
     if name is None:
         t = Tournament()
     else:
-        t = Tournament(name=name)
-    db.session.add(t)
-    db.session.commit()
-    create_players(t, count=n_players)
+        t = Tournament(
+            name=name,
+            description=f"Simulated Tournament - {num_byes} byes - {drops_per_round} drops - {drop_rate} drop rate",
+        )
+        db.session.add(t)
+        db.session.commit()
+    create_players(t, count=n_players, num_byes=num_byes)
     for _ in range(n_rounds):
         pair_round(t)
         sim_round(t)
+        drop_players(t, drops_per_round, drop_rate=drop_rate)
     return t
 
 
-def run_sims(n_tournaments: int, prefix: str = "Sim_", **kwargs):
-    t_list = []
+def clean_db():
+    db.drop_all()
+    db.create_all()
+    from data_models.users import User
+
+    admin = User()
+    db.session.commit()
+
+
+def test_tournaments(
+    n_tournaments: int,
+    n_players: int = 16,
+    n_rounds: int = 4,
+    name_prefix: str = "Sim_",
+    num_byes: int = 0,
+    drops_per_round: int = 0,
+    drop_rate: float = 0.9,
+):
+    clean_db()
+    # start = timer()
     for i in tqdm.trange(n_tournaments):
-        t_list.append(sim_tournament(name=prefix + str(i), **kwargs))
+        sim_tournament(
+            n_players=n_players,
+            n_rounds=n_rounds,
+            name=name_prefix + str(i),
+            num_byes=num_byes,
+            drops_per_round=drops_per_round,
+            drop_rate=drop_rate,
+        )
+        db.session.expunge_all()
+        db.session.commit()
+        # print(f"Tournament {i} finished in {timer() - start:.2f} seconds")
 
-    for t in t_list:
-        print(get_report(t))
+
+def create_report(t: Tournament):
+    import pandas as pd
+
+    # tournament_df = pd.read_sql(
+    #     f"SELECT * FROM tournament WHERE id = {t.id}",
+    #     db.engine,
+    # )
+    players_df = pd.read_sql(
+        f"SELECT * FROM player WHERE tid = {t.id}",
+        db.engine,
+    )
+    players_df = players_df.sort_values(
+        by=["score", "esos", "sos"], ascending=[False, False, False]
+    )
+    players_df["side_balance"] = players_df["id"].apply(
+        lambda x: p_logic.get_side_balance(db.session.get(Player, x))
+    )
+
+    side_balance = players_df["side_balance"].sum()
+    num_non_even_players = len(players_df[players_df["side_balance"] != 0])
+    num_active_non_even_players = len(
+        players_df[(players_df["side_balance"] != 0) & (players_df["active"])]
+    )
+    num_greater_than_one = len(players_df[abs(players_df["side_balance"]) > 1])
+    # return players_df[
+    #     [
+    #         "name",
+    #         "score",
+    #         "esos",
+    #         "sos",
+    #         "side_balance",
+    #     ]
+    # ]
+    return pd.DataFrame().from_dict(
+        {
+            "id": [t.id],
+            "side_balance": [side_balance],
+            "num_non_even_players": [num_non_even_players],
+            "num_active_non_even_players": [num_active_non_even_players],
+            "num_greater_than_one": [num_greater_than_one],
+        },
+        orient="columns",
+    )
 
 
-def get_report(t: Tournament, cutoff: int = 1):
-    players = t_logic.rank_players(t)
-    max_score = 0
-    num_max = 0
-    cutoff_score = 0
-    num_bubbled = 0
-    num_mismatched = 0
-    for i, player in enumerate(players):
-        if player.score > max_score:
-            max_score = player.score
-            num_max = 1
-        elif player.score == max_score:
-            num_max += 1
-        if len(player.corp_matches) != len(player.runner_matches):
-            num_mismatched += 1
+if __name__ == "__main__":
+    # N_PLAYERS = 20
+    # N_ROUNDS = 5
+    # N_BYES = 0
+    # DROPS_PER_ROUND = 0
+    # import cProfile
+    # from pstats import Stats, SortKey
 
-        if i == cutoff - 1:
-            cutoff_score = player.score
-            continue
-        if player.score == cutoff_score:
-            num_bubbled += 1
+    # with cProfile.Profile() as pr:
+    #     with app.app_context():
+    #         clean_db()
+    #         test_tournaments(
+    #             n_tournaments=50,
+    #             n_players=N_PLAYERS,
+    #             n_rounds=N_ROUNDS,
+    #             name_prefix="Sim_",
+    #             num_byes=N_BYES,
+    #             drops_per_round=DROPS_PER_ROUND,
+    #         )
+    #         tournaments = [create_report(t) for t in Tournament.query.all()]
+    #     import pandas as pd
 
-    return {
-        "id": t.id,
-        "max_score": max_score,
-        "num_bubbled": num_bubbled,
-        "num_uneven": num_mismatched,
-    }
+    #     pd.concat(tournaments).to_csv(
+    #         f"tournament_report_{N_PLAYERS}_{N_ROUNDS}_{DROPS_PER_ROUND}.csv",
+    #         index=False,
+    #     )
+    #     (Stats(pr).sort_stats(SortKey.CALLS).print_stats(20))
+
+    N_PLAYERS = 130
+    N_ROUNDS = 12
+    N_BYES = 8
+    DROPS_PER_ROUND = 3
+    with app.app_context():
+        clean_db()
+        test_tournaments(
+            n_tournaments=50,
+            n_players=N_PLAYERS,
+            n_rounds=N_ROUNDS,
+            name_prefix="Sim_",
+            num_byes=N_BYES,
+            drops_per_round=DROPS_PER_ROUND,
+        )
+        tournaments = [create_report(t) for t in Tournament.query.all()]
+    import pandas as pd
+
+    pd.concat(tournaments).to_csv(
+        f"tournament_report_{N_PLAYERS}_{N_ROUNDS}_{DROPS_PER_ROUND}.csv", index=False
+    )
+
+    N_PLAYERS = 420
+    N_ROUNDS = 14
+    N_BYES = 6
+    DROPS_PER_ROUND = 3
+    with app.app_context():
+        clean_db()
+        test_tournaments(
+            n_tournaments=25,
+            n_players=N_PLAYERS,
+            n_rounds=N_ROUNDS,
+            name_prefix="Sim_",
+            num_byes=N_BYES,
+            drops_per_round=DROPS_PER_ROUND,
+        )
+        tournaments = [create_report(t) for t in Tournament.query.all()]
+    import pandas as pd
+
+    pd.concat(tournaments).to_csv(
+        f"tournament_report_{N_PLAYERS}_{N_ROUNDS}_{DROPS_PER_ROUND}.csv", index=False
+    )


### PR DESCRIPTION
Made substantial algorithm changes as follows:

- Reverted pairing cost to be square of score differences
- Change side bias calculation to look at the current bias of the Corp/Runner proposal, and only apply a penalty if there is already a bias toward that side (new function is max(0, side bias) where side bias is the absolute magnitude of that bias
- Made the penalty go as 50^sb, because it's only kicking in going to +2, and want it to be larger than a 7 point (2W 1T) difference
- Increased the opposite side rematch penalty to 5  (1W 2T)